### PR TITLE
Add new filter 'BlackholeFilter'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 **Version 0.2.6** - Adding JSON formatter for OPEN messages
 
 **Version 0.2.7** - Adding OPEN message fields for line based output (ASN, Hold Time, Version, BGP Identifier)
- 
+
 **Version 0.2.8** - Adding prefix length field for line based output
 
 **Version 0.2.9** - Adding SLL-packet support (Linux cooked-packet), Fixing copyright notice
@@ -22,7 +22,7 @@
 
 **Version 0.2.11** - Fixing bug that causes trouble with missing tabs in line-based output
 
-**Version 0.2.12** - Removing functionless progress-flag; the function itself were already removed before first GitHub release 
+**Version 0.2.12** - Removing functionless progress-flag; the function itself were already removed before first GitHub release
 
 **Version 0.2.13** - Fixing bug within community filter
 
@@ -35,3 +35,5 @@
 **Version 0.2.17** - Improving HumanReadable Formatter
 
 **Version 0.2.18** - Fixing NEXT_HOP attribute output on JSON formatter
+
+**Version 0.2.19** - Add BlackholeFilter to filter blackhole routes based on NEXT_HOP or RFC 7999 community.

--- a/pbgpp/Application/CLI.py
+++ b/pbgpp/Application/CLI.py
@@ -68,6 +68,7 @@ def main():
     group_4.add_argument("--filter-destination-ip", help="only print messages containing the given destination IP address (e.g., '80.81.82.83')", nargs="+", action="append", dest="filter_destination_ip")
     group_4.add_argument("--filter-destination-mac", help="only print messages containing the given destination MAC address (e.g., 'aabbccddeeff')", nargs="+", action="append", dest="filter_destination_mac")
     group_4.add_argument("--filter-large-community", help="only print messages containing one or more matching large communities (e.g., '11:22:33', '11:*:*', '*:22:33')", nargs="+", action="append", dest="filter_large_community")
+    group_4.add_argument("--filter-blackhole", help="only print messages that contain blackhole prefixes with given next_hop (e.g. 80.81.193.66) OR RFC7999 well-known BGP community value", nargs="+", action="append", dest="filter_blackhole")
 
     group_5 = parser.add_argument_group("line output commands")
     group_5.add_argument("--fields", help="specify the output-fields to be display in the order desired; separated by comma. Available fields are: " + LineBasedFormatter.available_fields(), dest="fields", default=LineBasedFormatter.FIELD_MESSAGE_TIMESTAMP[0] + "," + LineBasedFormatter.FIELD_MESSAGE_TYPE[0] + "," + LineBasedFormatter.FIELD_UPDATE_SUBTYPE[0] + "," + LineBasedFormatter.FIELD_UPDATE_NLRI[0] + "," + LineBasedFormatter.FIELD_UPDATE_WITHDRAWN_ROUTES[0])

--- a/pbgpp/Application/Handler.py
+++ b/pbgpp/Application/Handler.py
@@ -28,6 +28,7 @@ import pcapy
 from pbgpp.BGP.Exceptions import BGPPacketHasNoMessagesError, BGPError
 from pbgpp.BGP.Packet import BGPPacket
 from pbgpp.Output.Filters.ASNFilter import ASNFilter
+from pbgpp.Output.Filters.BlackholeFilter import BlackholeFilter
 from pbgpp.Output.Filters.CommunityASNFilter import CommunityASNFilter
 from pbgpp.Output.Filters.CommunityValueFilter import CommunityValueFilter
 from pbgpp.Output.Filters.LargeCommunityFilter import LargeCommunityFilter
@@ -82,7 +83,7 @@ class PBGPPHandler:
 
         if self.args.version:
             print("pbgpp PCAP BGP Parser v0.2.18")
-            print("Copyright 2016-2017, DE-CIX Management GmbH")
+            print("Copyright 2016-2018, DE-CIX Management GmbH")
             sys.exit(0)
 
         if self.args.quiet:
@@ -191,6 +192,12 @@ class PBGPPHandler:
             filters = list(chain(*values))
             self.filters.append(MessageSizeFilter(filters))
             logger.debug("Added " + str(len(filters)) + " filter(s) of MessageSizeFilter")
+
+        if self.args.filter_blackhole:
+            values = self.args.filter_blackhole
+            filters = list(chain(*values))
+            self.filters.append(BlackholeFilter(filters))
+            logger.debug("Added " + str(len(filters)) + " filter of BlackholeFilter")
 
         if self.args.filter_source_ip:
             values = self.args.filter_source_ip

--- a/pbgpp/Application/Handler.py
+++ b/pbgpp/Application/Handler.py
@@ -82,7 +82,7 @@ class PBGPPHandler:
         logger = logging.getLogger('pbgpp.PBGPPHandler.handle')
 
         if self.args.version:
-            print("pbgpp PCAP BGP Parser v0.2.18")
+            print("pbgpp PCAP BGP Parser v0.2.19")
             print("Copyright 2016-2018, DE-CIX Management GmbH")
             sys.exit(0)
 

--- a/pbgpp/Output/Filters/BlackholeFilter.py
+++ b/pbgpp/Output/Filters/BlackholeFilter.py
@@ -1,0 +1,59 @@
+#
+# This file is part of PCAP BGP Parser (pbgpp)
+#
+# Copyright 2016-2018 DE-CIX Management GmbH
+# Author: Benedikt Rudolph <benedikt.rudolph@de-cix.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pbgpp.Output.Filter import BGPFilter
+from pbgpp.BGP.Statics import BGPStatics
+
+# This filter combines the two alternative ways to signal a blackhole routing
+# for a particular  prefix.
+#   * The legacy method is to set the next_hop attribute to a special IP address.
+#   * The preferred method is to set a well-known BGP Community value (RFC 7999).
+# The code for this filter is a combination of CommunityValueFilter and NextHopFilter.
+class BlackholeFilter(BGPFilter):
+    def __init__(self, values=[]):
+        BGPFilter.__init__(self, values)
+
+    def apply(self, message):
+        try:
+            # NEXT_HOP and COMMUNITIES are attributes of a BGP UPDATE message
+            if message.type is not BGPStatics.MESSAGE_TYPE_UPDATE:
+                # Skip messages that are no UPDATE messages
+                return None
+
+            for attribute in message.path_attributes:
+                # Skip attributes that are no NEXT_HOP attributes
+                if attribute.type is BGPStatics.UPDATE_ATTRIBUTE_NEXT_HOP:
+                    # Here we found the NEXT_HOP attribute - check for blackhole next_hop
+                    for value in self.values:
+                        if str(BGPRoute.decimal_ip_to_string(attribute.next_hop)) == str(value):
+                            # Match on NEXT_HOP attribute - Return message
+                            return message
+
+                # Alternatively check if well-known BGP community is set (RFC 7999)
+                if attribute.type is BGPStatics.UPDATE_ATTRIBUTE_COMMUNITIES:
+
+                    for community in attribute.communities:
+                        if community.asn == 65535 and community.value == 666:
+                          return message
+
+            # Searched value was not found
+            return None
+        except Exception as e:
+            # On error the filtering was not successful (due to wrong fields, etc.)
+            return None

--- a/pbgpp/Output/Filters/BlackholeFilter.py
+++ b/pbgpp/Output/Filters/BlackholeFilter.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+from pbgpp.BGP.Update.Route import BGPRoute
 from pbgpp.Output.Filter import BGPFilter
 from pbgpp.BGP.Statics import BGPStatics
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ packages.append('pbgpp')
 
 setup(
     name='pbgpp',
-    version='0.2.18',
+    version='0.2.19',
     description='PCAP BGP Parser',
     author='DE-CIX Management GmbH',
     author_email='rnd@de-cix.net',


### PR DESCRIPTION
This pull request adds a new filter to filter blackhole routes.
To use it add `--filter-blackhole $BLACKHOLE_IP` to your command line.

This filter combines the two alternative ways to signal a blackhole routing
for a particular prefix.
  * The legacy method is to set the next_hop attribute to a special IP address ($BLACKHOLE_IP).
  * The preferred method is to set a well-known BGP Community value (RFC 7999).

The code for this filter is a combination of CommunityValueFilter and NextHopFilter.