### PR TITLE
Removing path attribute pre-check on UPDATE messages

### DIFF
--- a/pbgpp/BGP/Update/Message.py
+++ b/pbgpp/BGP/Update/Message.py
@@ -49,10 +49,6 @@ class BGPUpdateMessage(BGPMessage):
         self.parsed = True
 
         try:
-            # Check last two bytes of byte payload - if they are set to zero we don't have any path attributes
-            if struct.unpack("!H", self.payload[-2:])[0] == 0:
-                self.path_attributes_length = 0
-
             # Unpack the length of withdrawn routes field and add 2 bytes to the current byte marker position
             self.withdrawn_routes_length = struct.unpack("!H", self.payload[:2])[0]
             current_byte_position = 2


### PR DESCRIPTION
The error that has been raised in issue #35 leads to a problem within the pre-checking of path attributes. The check tried to parse the last two bytes of the BGP message and would set the `path_attribute_length` variable to 0 which leads to a skip of the path attribute parsing. This was obviously not correct and the resulting bitshift would return in illogical outputs.

```0000   ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
0010   00 66 02 00 00 00 2f 40 01 01 00 40 02 16 02 05
0020   00 00 3e 47 00 00 3e 47 00 03 21 fe 00 00 20 1c
0030   00 00 34 17 40 03 04 50 51 c2 ff c0 07 08 00 00
0040   34 17 a2 9e 84 01 14 68 12 40 14 68 11 f0 14 68
0050   10 d0 14 68 10 90 14 68 11 b0 17 17 e3 26 18 01
0060   01 01 18 01 --> 00 00 <--
```

This example message has an actual total path attribute length of 47 bytes but due to the two zeroed bytes at the end of the message the parsing would skip those 47 bytes of path attributes. I guess that this check was originally implemented to gain performance upon mass-parsing.

This pull requests removes the pre-check and shifts the responsibility for parsing the path attributes to the following lines in the affected file. There is a check that actually verifies the length of the path attributes that are stored within the BGP message itself.

**Before**
```[BGPMessage UPDATE] - 102 Bytes
|- MAC: 00:8a:96:95:60:dc -> 90:e2:ba:b8:72:38
|- IP: 80.81.194.255:41535 -> 80.81.192.157:179
|- Timestamp: 2020-04-23 08:26:42.283043 (1587630402.283043)
|
|- Update Message Sub-Type: NONE
|- Withdrawn Routes Length: 0 Bytes
|- Total Path Attribute Length: 0 Bytes
|- Prefix (NLRI):
|--- 1.1.0.64/64
|--- 22.0.0.0/2
|--- 5.0.0.0/2
|--- 0.0.0.0/0
|--- 71.0.0.62/62
|--- 0.3.33.254/71
|--- 0.0.0.0/0
|--- 28.0.0.52/32
|--- 64.3.4.0/23
|--- 81.194.255.192/80
|--- 8.0.0.0/7
|--- 0.0.0.0/0
|--- 23.162.158.132/52
|--- 20.0.0.0/1
|--- 18.64.20.104/104
|--- 240.20.104.0/17
|--- 208.20.0.0/16
|--- 16.144.20.104/104
|--- 176.23.23.0/17
|--- 38.24.1.1/227
|--- 24.0.0.0/1
|--- 0.0.0.0/1
```

**After**
```
[BGPMessage UPDATE] - 102 Bytes
|- MAC: 00:8a:96:95:60:dc -> 90:e2:ba:b8:72:38
|- IP: 80.81.194.255:41535 -> 80.81.192.157:179
|- Timestamp: 2020-04-23 08:26:42.283043 (1587630402.283043)
|
|- Update Message Sub-Type: ANNOUNCE
|- Withdrawn Routes Length: 0 Bytes
|- Total Path Attribute Length: 47 Bytes
|- Prefix (NLRI):
|--- 104.18.64.0/20
|--- 104.17.240.0/20
|--- 104.16.208.0/20
|--- 104.16.144.0/20
|--- 104.17.176.0/20
|--- 23.227.38.0/23
|--- 1.1.1.0/24
|--- 1.0.0.0/24
|- Path Attributes:
|--- ORIGIN: IGP
|- Path Attributes:
|--- AS_PATH: 15943 15943 205310 8220 13335
|- Path Attributes:
|--- NEXT_HOP: 80.81.194.255
|- Path Attributes:
|--- AGGREGATOR: 
```