### PR TITLE
Add-Path capabilty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,5 @@
 **Version 0.2.19** - Add BlackholeFilter to filter blackhole routes based on NEXT_HOP or RFC 7999 community
 
 **Version 0.2.20** - Fixing bug output of large communities when using the LineBased formatter
+
+**Version 0.2.20** - Add-Path capability added (RFC7911)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,22 @@ pbgpp is producing logging output while parsing your PCAP input. The default opt
 
     # This command will pipe parsing output to stdout and log output at DEBUG level to stderr
     cat /path/to/file.pcap | pbgpp.py -p STDOUT --verbose 2> /path/to/output.log
-    
+
 **Note**, if you are not using stream redirection in combination with verbose or normal logging level you won't be able to separate parsing output from logging output.
+
+## BGP Add-Path (RFC7911)
+IETF introduced with RFC7911 the so called Add-Path feature. As mentioned in this RFC, a packet analyzer can not distinguish between a standard network prefix and a PathIdentifier.
+Therefore we implemented the following feature. A user is now able to toggle a Flag which allows three different interpretation modes of the NLRI fields.
+
+    #Use the flag like this: `--add-path-metric [0|1|2]`
+    pbgpp.py  --pcap my.pcap --add-path-metric 2
+
+0 (default): Assume that there are **no** Add-Path messages 
+
+1: Assume that there are **only** Add-Path messages
+
+2: Use the implemented metric. 
+If the NLRI field contains two 0-Bytes (translated to two 0.0.0.0/0 prefixes which should not occur at all) the programm assumes that the first 4 bytes are a Path Identifier and treates this field as an Add-Path message.  
 
 ## Limitations
 Currently, the parser doesn't perform a reassembly on fragmented TCP packets. This may leads into parsing errors and application warnings when you are trying to parse large BGP packets with several messages.

--- a/pbgpp/Application/CLI.py
+++ b/pbgpp/Application/CLI.py
@@ -76,6 +76,9 @@ def main():
     group_6 = parser.add_argument_group("other commands")
     group_6.add_argument("--version", help="displays the current version of this software", action="store_true", dest="version")
 
+    group_7 = parser.add_argument_group("interpreter options")
+    group_7.add_argument("--add-path-metric", help="decide how to interpret UPDATE messages (0 = no add_path messages, 1 = only add_path messages, 2 = use implemented metric(!)", nargs=1, type=int, dest="add_path_metric")
+
     main_handler = PBGPPHandler(parser)
 
     try:

--- a/pbgpp/Application/Flags/AddPathFlag.py
+++ b/pbgpp/Application/Flags/AddPathFlag.py
@@ -1,0 +1,30 @@
+#
+# This file is part of PCAP BGP Parser (pbgpp)
+#
+# Copyright 2016-2017 DE-CIX Management GmbH
+# Author: Christopher Moeller <christopher.moeller@de-cix.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pbgpp.Application.Flags.Exceptions import FlagHandlerError, FlagError
+from pbgpp.Application.Flags.Flag import Flag
+
+
+class AddPathFlag(Flag):
+    
+    def __init__(self, value=0):
+        self.default_value = 0
+        self.compatible_values = [0, 1, 2]
+
+        self.set_value(value)

--- a/pbgpp/Application/Flags/AddPathFlag.py
+++ b/pbgpp/Application/Flags/AddPathFlag.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-from pbgpp.Application.Flags.Exceptions import FlagHandlerError, FlagError
+from pbgpp.Application.Flags.Exceptions import FlagError
 from pbgpp.Application.Flags.Flag import Flag
 
 

--- a/pbgpp/Application/Flags/Exceptions.py
+++ b/pbgpp/Application/Flags/Exceptions.py
@@ -1,0 +1,24 @@
+#
+# This file is part of PCAP BGP Parser (pbgpp)
+#
+# Copyright 2016-2017 DE-CIX Management GmbH
+# Author: Christopher Moeller <christopher.moeller@de-cix.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class FlagError(Exception):
+    def __init__(self, message, errno = None):
+        self.message = message
+        self.errno = errno
+

--- a/pbgpp/Application/Flags/Flag.py
+++ b/pbgpp/Application/Flags/Flag.py
@@ -1,0 +1,46 @@
+#
+# This file is part of PCAP BGP Parser (pbgpp)
+#
+# Copyright 2016-2017 DE-CIX Management GmbH
+# Author: Christopher Moeller <christopher.moeller@de-cix.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pbgpp.Application.Flags.Exceptions import FlagError
+
+
+class Flag: 
+    # @todo representation of the flag.
+    def __init__(self):
+        self.default_value = 0
+        self.value = 0
+        self.compatible_values = []
+
+    def __eq__(self, other):
+        if isinstance(Flag, other):
+            return self.value == other.value
+        else:
+            return self.value == other
+            
+    def set_value(self, value):
+        if len(self.compatible_values) == 0:
+            raise FlagError("Cant set value of uninitialized flag")
+
+        if value not in self.compatible_values:
+            raise FlagError("AddPathFlag: incompatible value")
+        else:
+            self.value = value
+
+    def get_value(self):
+        return self.value

--- a/pbgpp/BGP/Message.py
+++ b/pbgpp/BGP/Message.py
@@ -25,13 +25,14 @@ from pbgpp.BGP.Translation import BGPTranslation
 
 
 class BGPMessage:
-    def __init__(self, payload, length, pcap_information):
+    def __init__(self, payload, length, pcap_information, flags=None):
         self.payload = payload
         self.length = length
         self.type = None
         self.parsed = False
         self.error = None
         self.pcap_information = pcap_information
+        self.flags = flags
 
     def __str__(self):
         # Return the string identifier of the BGP message
@@ -100,7 +101,7 @@ class BGPMessage:
         return self.length
 
     @staticmethod
-    def factory(payload, pcap_information):
+    def factory(payload, pcap_information, flags=None):
         logger = logging.getLogger("pbgpp.BGPMessage.factory")
 
         # Implement factory pattern for easy message class creation
@@ -108,7 +109,7 @@ class BGPMessage:
         # The byte after message length is the message type
         try:
             bgp_header = struct.unpack("!HB", payload[:3])
-        except Exception as e:
+        except Exception:
             # This could happen on a malformed packet
             logger.debug("Unpacking first 3 bytes of BGP message (length and type) failed.")
             raise BGPMessageFactoryError("given payload has no valid message type.")
@@ -123,7 +124,7 @@ class BGPMessage:
 
         if message_type == BGPStatics.MESSAGE_TYPE_UPDATE:
             from pbgpp.BGP.Update.Message import BGPUpdateMessage
-            return BGPUpdateMessage(payload[3:], message_length, pcap_information)
+            return BGPUpdateMessage(payload[3:], message_length, pcap_information, flags)
 
         if message_type == BGPStatics.MESSAGE_TYPE_KEEPALIVE:
             from pbgpp.BGP.Keepalive.Message import BGPKeepaliveMessage

--- a/pbgpp/BGP/Packet.py
+++ b/pbgpp/BGP/Packet.py
@@ -26,7 +26,7 @@ from pbgpp.PCAP.Information import PCAPInformation
 
 
 class BGPPacket:
-    def __init__(self, payload, pcap_information):
+    def __init__(self, payload, pcap_information, flags=None):
         # Assign payload and pcap information
         self.payload = payload
         self.pcap_information = pcap_information
@@ -34,6 +34,7 @@ class BGPPacket:
         self.message_list = []
         self.__parsed = False
         self.__iteration_position = 0
+        self.flags = flags
 
         # Typecheck pcap information
         if not isinstance(self.pcap_information, PCAPInformation):
@@ -97,7 +98,7 @@ class BGPPacket:
         for m in messages:
             try:
                 # ... and add them to the message list of packet object using a message factory pattern
-                self.add_message(BGPMessage.factory(m, self.pcap_information))
+                self.add_message(BGPMessage.factory(m, self.pcap_information, self.flags))
             except BGPMessageFactoryError as f:
                 # This exception can be raised when no valid message type could be found
                 # It's a common exception when there is a malformed packet - therefore: log it as INFO

--- a/pbgpp/BGP/Update/Message.py
+++ b/pbgpp/BGP/Update/Message.py
@@ -29,7 +29,7 @@ from pbgpp.BGP.Update.Route import BGPRoute
 
 
 class BGPUpdateMessage(BGPMessage):
-    def __init__(self, payload, length, pcap_information):
+    def __init__(self, payload, length, pcap_information, flags=None):
         BGPMessage.__init__(self, payload, length, pcap_information)
         self.type = BGPStatics.MESSAGE_TYPE_UPDATE
         self.subtype = BGPStatics.UPDATE_TYPE_NONE
@@ -42,6 +42,11 @@ class BGPUpdateMessage(BGPMessage):
         self.withdrawn_routes_length = None
 
         self.nlri = []
+
+        self.path_id = None
+        self.add_path = False
+
+        self.flags = flags
 
         self.__parse()
 
@@ -151,13 +156,44 @@ class BGPUpdateMessage(BGPMessage):
                 current_byte_position = self.path_attributes_length + 4 + self.withdrawn_routes_length
 
                 while continue_loop:
+                    """
+                    The Following is a Fix for missing Add_Path feature.
+                    Due to the lack of a definition for this case, we need depend on the users decision.
+                    See RFC 7911 Chapter 6 p.5 (22.07.2020).
+
+                    In most cases, the pathId is lower than 2**16. Also it is uncommon,
+                    that one BGP UPDATE message contains the 0.0.0.0/0 prefix 2 times.
+                    This leads to the following metric if the user sets the add_path_flag to 2.
+                    """
+                    # AddPath assumption?
+                    if self.flags["addpath"].get_value() == 0: # No AddPath messages
+                        pass
+
+                    else:
+                        pathId_length_bytes = self.payload[current_byte_position:current_byte_position + 4]
+                        pathId = struct.unpack("!I", pathId_length_bytes)[0]
+
+                        if  self.flags["addpath"].get_value() == 1: # Only AddPath
+                            self.add_path = True
+                            self.path_id = pathId
+                            current_byte_position += 4
+                            
+                        else:                           # Try to find out (using metric)
+                            if pathId < 65536:
+                                self.add_path = True
+                                self.path_id = pathId
+                                current_byte_position += 4
+                            #else: drop the Path Id, its likely that this is not an AddPath msg
+
                     # First of all we have to check the prefix length as byte-length of the following
                     # prefix depends on its prefix length (This is a 1-byte-field)
                     prefix_length_bytes = self.payload[current_byte_position:current_byte_position + 1]
                     prefix_length = struct.unpack("!B", prefix_length_bytes)[0]
                     current_byte_position += 1
 
-                    if 0 <= prefix_length <= 8:
+                    if prefix_length == 0: #0.0.0.0/0
+                        prefix_bytes = prefix_length_bytes
+                    elif 0 < prefix_length <= 8:
                         # Length of prefix field: 1 Byte
                         prefix_bytes = self.payload[current_byte_position:current_byte_position + 1]
                         current_byte_position += 1

--- a/pbgpp/Output/Formatters/HumanReadable.py
+++ b/pbgpp/Output/Formatters/HumanReadable.py
@@ -132,7 +132,10 @@ class HumanReadableFormatter(BGPFormatter):
 
             # --- Withdrawn Routes
             if message.withdrawn_routes_length > 0:
-                string += self.prefix(0) + "Withdrawn Routes:" + "\n"
+                string += self.prefix(0) + "Withdrawn Routes:"
+                if message.add_path:
+                    string += " (AddPath)\n" + self.prefix(0) + "Path Identifier: " + str(message.path_id)
+                string += "\n"
 
                 # Process withdrawn routes
                 for route in message.withdrawn_routes:

--- a/pbgpp/Output/Formatters/HumanReadable.py
+++ b/pbgpp/Output/Formatters/HumanReadable.py
@@ -104,7 +104,10 @@ class HumanReadableFormatter(BGPFormatter):
 
             # --- NLRI
             if len(message.nlri) > 0:
-                string += self.prefix(0) + "Prefix (NLRI):" + "\n"
+                string += self.prefix(0) + "Prefix (NLRI):"
+                if message.add_path:
+                    string += " (AddPath)\n" + self.prefix(0) + "Path Identifier: " + str(message.path_id)
+                string += "\n"
 
                 # Process NLRI
                 for route in message.nlri:

--- a/pbgpp/Output/Formatters/JSON.py
+++ b/pbgpp/Output/Formatters/JSON.py
@@ -104,7 +104,11 @@ class JSONFormatter(BGPFormatter):
             # Assign to message data
             message_data["path_attributes"] = path_attributes
             message_data["withdrawn_routes"] = withdrawn_routes
-            message_data["nlri"] = nlri
+            if message.add_path:
+                message_data["pathId"] = message.path_id
+            else:
+                message_data["pathId"] = "None"
+            message_data["nlri"] = nlri 
 
             # Assign message data to return data
             data["message_data"] = message_data

--- a/pbgpp/Output/Formatters/JSON.py
+++ b/pbgpp/Output/Formatters/JSON.py
@@ -79,6 +79,7 @@ class JSONFormatter(BGPFormatter):
 
                 "path_attributes": None,
                 "withdrawn_routes": None,
+                "pathId": None,
                 "nlri": None
             }
 
@@ -103,11 +104,9 @@ class JSONFormatter(BGPFormatter):
 
             # Assign to message data
             message_data["path_attributes"] = path_attributes
-            message_data["withdrawn_routes"] = withdrawn_routes
             if message.add_path:
                 message_data["pathId"] = message.path_id
-            else:
-                message_data["pathId"] = "None"
+            message_data["withdrawn_routes"] = withdrawn_routes
             message_data["nlri"] = nlri 
 
             # Assign message data to return data

--- a/pbgpp/Output/Formatters/LineBased.py
+++ b/pbgpp/Output/Formatters/LineBased.py
@@ -39,9 +39,9 @@ class LineBasedFormatter(BGPFormatter):
 
     FIELD_UPDATE_SUBTYPE = ["subtype"]
     FIELD_UPDATE_PATH_ATTRIBUTES_LENGTH = ["path_attributes_length"]
+    FIELD_UPDATE_PATH_IDENTIFIER = ["path_id", "path_identifier"]
     FIELD_UPDATE_WITHDRAWN_ROUTES_LENGTH = ["withdrawn_routes_length"]
     FIELD_UPDATE_WITHDRAWN_ROUTES = ["withdrawn_routes", "withdrawn_route", "withdrawals"]
-    FIELD_UPDATE_NLRI_PATH_IDENTIFIER = ["path_id", "path_identifier"]
     FIELD_UPDATE_NLRI = ["prefixes", "prefix", "nlri"]
     FIELD_UPDATE_NLRI_LENGTH = ["prefix_length"]
     FIELD_UPDATE_ATTRIBUTE_ORIGIN = ["origin"]
@@ -65,9 +65,9 @@ class LineBasedFormatter(BGPFormatter):
                          FIELD_MESSAGE_TYPE,
                          FIELD_UPDATE_SUBTYPE,
                          FIELD_UPDATE_PATH_ATTRIBUTES_LENGTH,
+                         FIELD_UPDATE_PATH_IDENTIFIER,
                          FIELD_UPDATE_WITHDRAWN_ROUTES_LENGTH,
                          FIELD_UPDATE_WITHDRAWN_ROUTES,
-                         FIELD_UPDATE_NLRI_PATH_IDENTIFIER,
                          FIELD_UPDATE_NLRI,
                          FIELD_UPDATE_NLRI_LENGTH,
                          FIELD_UPDATE_ATTRIBUTE_ORIGIN,
@@ -195,7 +195,7 @@ class LineBasedFormatter(BGPFormatter):
             return None
 
         # Path Identifier
-        if f in self.FIELD_UPDATE_NLRI_PATH_IDENTIFIER:
+        if f in self.FIELD_UPDATE_PATH_IDENTIFIER:
             add_path = getattr(message, "add_path", False)
             if add_path:
                 return [message.path_id]

--- a/pbgpp/Output/Formatters/LineBased.py
+++ b/pbgpp/Output/Formatters/LineBased.py
@@ -41,6 +41,7 @@ class LineBasedFormatter(BGPFormatter):
     FIELD_UPDATE_PATH_ATTRIBUTES_LENGTH = ["path_attributes_length"]
     FIELD_UPDATE_WITHDRAWN_ROUTES_LENGTH = ["withdrawn_routes_length"]
     FIELD_UPDATE_WITHDRAWN_ROUTES = ["withdrawn_routes", "withdrawn_route", "withdrawals"]
+    FIELD_UPDATE_NLRI_PATH_IDENTIFIER = ["path_id", "path_identifier"]
     FIELD_UPDATE_NLRI = ["prefixes", "prefix", "nlri"]
     FIELD_UPDATE_NLRI_LENGTH = ["prefix_length"]
     FIELD_UPDATE_ATTRIBUTE_ORIGIN = ["origin"]
@@ -66,6 +67,7 @@ class LineBasedFormatter(BGPFormatter):
                          FIELD_UPDATE_PATH_ATTRIBUTES_LENGTH,
                          FIELD_UPDATE_WITHDRAWN_ROUTES_LENGTH,
                          FIELD_UPDATE_WITHDRAWN_ROUTES,
+                         FIELD_UPDATE_NLRI_PATH_IDENTIFIER,
                          FIELD_UPDATE_NLRI,
                          FIELD_UPDATE_NLRI_LENGTH,
                          FIELD_UPDATE_ATTRIBUTE_ORIGIN,
@@ -190,6 +192,13 @@ class LineBasedFormatter(BGPFormatter):
             w_routes = getattr(message, "withdrawn_routes", False)
             if w_routes:
                 return [str(r) for r in w_routes]
+            return None
+
+        # Path Identifier
+        if f in self.FIELD_UPDATE_NLRI_PATH_IDENTIFIER:
+            add_path = getattr(message, "add_path", False)
+            if add_path:
+                return [message.path_id]
             return None
 
         # NLRI (announced prefixes)

--- a/pbgpp/PCAP/Ethernet.py
+++ b/pbgpp/PCAP/Ethernet.py
@@ -48,7 +48,7 @@ class PCAPEthernet:
             self.mac = PCAPLayer2Information(self.payload[6:12], self.payload[:6])
 
         except Exception as e:
-            logging.error("Parsing ethernet frame caused exception (message: " + e.message + ")")
+            logging.error("Parsing ethernet frame caused exception (message: " + e.message + ")") #str(e)
             self.parsing_error = True
 
     def get_type(self):


### PR DESCRIPTION
This change allows the parser to deal with Add-Path messages.
According to RFC7911, it is difficult for a packet analyzer to determine if a message contains an Add-Path field or not.

Therefore i implemented a flag which lets the user decide how a pcap should be processed.
Using the `--add-path-metric` flag will result in the following cases:

`--add-path-metric 0` : default behavior - assume there are **no** Add-Path fields.

`--add-path-metric 1` : assume there are **only** Add-Path fields.

`--add-path-metric 2` : Use the implemented metric to decide whether the current message contains any Add-Path fields or not (explanation below).

The first 4 bytes in a NLRI-Field can be the so called Path-Identifier (if add-path is enabled) or a address  prefix.
If the first 2 bytes are 0 (0byte get translated to the prefix 0.0.0.0/0) it is more likely that this is a PathID since sending two times the same prefix is uncommon.
 
The flag 2 feature worked pretty well so far, but be aware of possible misinterpretation of the NLRI-Field.